### PR TITLE
fix(lib/spree/chimpy/interface/products.rb): Fix bug POST call for new products

### DIFF
--- a/lib/spree/chimpy/interface/products.rb
+++ b/lib/spree/chimpy/interface/products.rb
@@ -86,15 +86,20 @@ module Spree::Chimpy
       end
 
       def self.variant_hash(variant)
-        {
+        data = {
           id: mailchimp_variant_id(variant),
           title: variant.name,
           sku: variant.sku,
           url: product_url_or_default(variant.product),
           price: variant.price.to_f,
-          image_url: variant_image_url(variant),
+
           inventory_quantity: variant.total_on_hand == Float::INFINITY ? 999 : variant.total_on_hand
         }
+
+        if variant.images.any?
+          data[:image_url] = variant_image_url variant
+        end
+        data
       end
 
       def self.variant_image_url(variant)


### PR DESCRIPTION
Fix bug in MailChimp API POST call for new products when variants have no images. 

Modify the `self.variant_hash` method of the Products interface
-- Only include the `:image_url` if a vairant image is present. This is an optional key, but causes an error in the MailChimp API if set to `nil`. This error prevents the insertion of the product and the associated order. 

`:image_url` should be excluded if there is no image to include to avoid this error.